### PR TITLE
fix rmt_storage denial

### DIFF
--- a/sepolicy/rmt_storage.te
+++ b/sepolicy/rmt_storage.te
@@ -8,3 +8,4 @@ allow rmt_storage property_socket:sock_file write;
 allow rmt_storage rmtfs_prop:property_service set;
 allow rmt_storage self:capability net_raw;
 allow rmt_storage unlabeled:file { open read };
+allow rmt_storage self:capability dac_override;


### PR DESCRIPTION
*this fixes no sim card after caf rebase
*avc: denied { dac_override } for pid=314 comm="rmt_storage"
capability=1 scontext=u:r:rmt_storage:s0 tcontext=u:r:rmt_storage:s0
tclass=capability permissive=0
Change-Id: I09ab419bd2fd1fb9ddeb3b8c670df15075a73a51