### PR TITLE
Add 2G option in Preferred network type

### DIFF
--- a/overlay/packages/services/Telephony/res/values/config.xml
+++ b/overlay/packages/services/Telephony/res/values/config.xml
@@ -20,7 +20,9 @@
          the com.android.internal.telephony.Phone interface (false). -->
     <bool name="send_mic_mute_to_AudioManager">true</bool>
 
-    <!-- Show enabled lte option for lte device -->
+    <!-- Show available options for lte device -->
     <bool name="config_enabled_lte" translatable="false">true</bool>
+    <bool name="config_enabled_wcdma" translatable="false">true</bool>
+    <bool name="config_enabled_gsm" translatable="false">true</bool> 
 
 </resources>


### PR DESCRIPTION
Adding 2g option in preferred network type saves battery where 3g is poor and also for people who just want their phone to be in 2g unless they want to use Mobile Data.